### PR TITLE
feat: Implement image loading and sharing utilities

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Add this inside the <application> tag in your AndroidManifest.xml -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_path" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/handballconnect/util/ImageLoadingUtils.kt
+++ b/app/src/main/java/com/example/handballconnect/util/ImageLoadingUtils.kt
@@ -1,0 +1,102 @@
+package com.example.handballconnect.util
+
+import android.net.Uri
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil.compose.AsyncImage
+import coil.compose.AsyncImagePainter
+import coil.request.ImageRequest
+import com.example.handballconnect.data.storage.ImageStorageManager
+import javax.inject.Inject
+
+/**
+ * Utility class for handling image loading with local references
+ */
+class ImageLoadingUtils @Inject constructor(
+    private val imageStorageManager: ImageStorageManager
+) {
+    /**
+     * Resolves an image reference to a proper URI
+     * @param imageReference Can be a local reference or a regular HTTP URL
+     * @return The URI to use for loading, or null if the image can't be resolved
+     */
+    fun resolveImageUri(imageReference: String?): Uri? {
+        if (imageReference == null || imageReference.isEmpty()) {
+            return null
+        }
+        
+        return if (imageReference.startsWith(ImageStorageManager.LOCAL_URI_PREFIX)) {
+            // It's a local image, get the proper URI
+            imageStorageManager.getImageUri(imageReference)
+        } else if (imageReference.startsWith("http")) {
+            // It's a remote URL
+            Uri.parse(imageReference)
+        } else {
+            // Unknown format
+            null
+        }
+    }
+    
+    /**
+     * Gets a fallback URL for when an image can't be loaded
+     */
+    fun getFallbackImageUrl(size: Int = 100): String {
+        return "https://via.placeholder.com/${size}x${size}"
+    }
+}
+
+/**
+ * Composable for loading images with local reference support
+ */
+@Composable
+fun LocalAwareAsyncImage(
+    imageReference: String?,
+    imageStorageManager: ImageStorageManager,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Crop,
+    showLoading: Boolean = true,
+    fallbackImageUrl: String? = null
+) {
+    val context = LocalContext.current
+    
+    val imageUri = remember(imageReference) {
+        if (imageReference?.startsWith(ImageStorageManager.LOCAL_URI_PREFIX) == true) {
+            // It's a local image
+            imageStorageManager.getImageUri(imageReference)
+        } else if (imageReference?.startsWith("http") == true) {
+            // It's a remote URL
+            Uri.parse(imageReference)
+        } else {
+            // Use fallback or null
+            fallbackImageUrl?.let { Uri.parse(it) }
+        }
+    }
+    
+    AsyncImage(
+        model = ImageRequest.Builder(context)
+            .data(imageUri)
+            .crossfade(true)
+            .build(),
+        contentDescription = contentDescription,
+        modifier = modifier,
+        contentScale = contentScale,
+        onState = { state ->
+            if (state is AsyncImagePainter.State.Loading && showLoading) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/res/xml/file_path.xml
+++ b/app/src/main/res/xml/file_path.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <files-path name="profile_images" path="profile_images/"/>
+    <files-path name="post_images" path="post_images/"/>
+    <files-path name="shared_images" path="."/>
+</paths>


### PR DESCRIPTION
This commit introduces utilities for handling image loading and sharing within the app.

- Adds `ImageLoadingUtils` for resolving image URIs, supporting both local and remote images, and providing fallback URLs.
- Implements `LocalAwareAsyncImage` composable for loading images with local reference support in Compose.
- Sets up a `FileProvider` in `AndroidManifest.xml` to securely share files between apps, as per [Setting up file sharing | App data and files - Android Developers](https://developer.android.com/training/secure-file-sharing/setup-sharing).
- Creates `file_path.xml` to define shareable directories for profile images, post images, and shared images, used by the `FileProvider` as documented in [<provider> | App architecture - Android Developers](https://developer.android.com/guide/topics/manifest/provider-element).