### PR TITLE
feat: Implement admin controls for user roles and account status

### DIFF
--- a/app/src/main/java/com/example/handballconnect/data/model/User.kt
+++ b/app/src/main/java/com/example/handballconnect/data/model/User.kt
@@ -30,11 +30,13 @@ data class User(
     @PropertyName("admin")
     val isAdmin: Boolean = false,
 
+    var isDisabled: Boolean = false,
+
     @PropertyName("createdAt")
     val createdAt: Long = Date().time
 ) {
     // Empty constructor needed for Firebase
-    constructor() : this("", "", "", "", "", "", false, 0)
+    constructor() : this("", "", "", "", "", "", false, false,0)
 
     fun toMap(): Map<String, Any?> {
         return mapOf(
@@ -45,6 +47,7 @@ data class User(
             "position" to position,
             "experience" to experience,
             "admin" to isAdmin,
+            "isDisabled" to isDisabled,
             "createdAt" to createdAt
         )
     }

--- a/app/src/main/java/com/example/handballconnect/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/handballconnect/data/repository/UserRepository.kt
@@ -300,64 +300,33 @@ class UserRepository @Inject constructor(
     // Update user admin status
     suspend fun updateUserAdminStatus(userId: String, isAdmin: Boolean): Result<Unit> {
         return try {
-            userCollection.document(userId).update("isAdmin", isAdmin).await()
+            userCollection.document(userId).update("admin", isAdmin).await()
             Result.success(Unit)
         } catch (e: Exception) {
             Result.failure(e)
         }
     }
 
-    /**
-     * Checks and fixes the admin status for a user
-     * This is helpful when there might be a field name mismatch between "admin" and "isAdmin"
-     */
-    suspend fun checkAndFixAdminStatus(userId: String? = null): Result<Boolean> {
-        // Use the provided userId or the current user's ID
-        val targetUserId = userId ?: getCurrentUserId() ?:
-        return Result.failure(Exception("User not logged in"))
-
-        try {
-            Log.d("UserRepository", "Checking admin status for user: $targetUserId")
-
-            // Get the user document
-            val userDoc = userCollection.document(targetUserId).get().await()
-
-            if (!userDoc.exists()) {
-                Log.e("UserRepository", "User document doesn't exist")
-                return Result.failure(Exception("User not found"))
-            }
-
-            // Log all fields for debugging
-            Log.d("UserRepository", "User document data: ${userDoc.data}")
-
-            // Check for "admin" field
-            val adminValue = userDoc.getBoolean("admin")
-            Log.d("UserRepository", "Admin field value: $adminValue")
-
-            // Check for "isAdmin" field
-            val isAdminValue = userDoc.getBoolean("isAdmin")
-            Log.d("UserRepository", "isAdmin field value: $isAdminValue")
-
-            // Determine the actual admin status
-            val shouldBeAdmin = adminValue ?: isAdminValue ?: false
-
-            // If we have conflicting values or a missing field, fix it
-            if (adminValue != isAdminValue || adminValue == null || isAdminValue == null) {
-                Log.d("UserRepository", "Fixing admin status to be consistent: $shouldBeAdmin")
-
-                val updates = hashMapOf<String, Any>(
-                    "admin" to shouldBeAdmin,
-                    "isAdmin" to shouldBeAdmin
-                )
-
-                userCollection.document(targetUserId).update(updates).await()
-                Log.d("UserRepository", "Updated admin fields: $updates")
-            }
-
-            return Result.success(shouldBeAdmin)
+    // In UserRepository.kt
+    suspend fun setUserAdminStatus(userId: String, isAdmin: Boolean): Result<Unit> {
+        return try {
+            userCollection.document(userId).update("admin", isAdmin).await()
+            Result.success(Unit)
         } catch (e: Exception) {
-            Log.e("UserRepository", "Error checking/fixing admin status: ${e.message}", e)
-            return Result.failure(e)
+            Log.e("UserRepository", "Error updating admin status: ${e.message}")
+            Result.failure(e)
         }
     }
+
+    suspend fun setUserDisabledStatus(userId: String, isDisabled: Boolean): Result<Unit> {
+        return try {
+            userCollection.document(userId).update("isDisabled", isDisabled).await()
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Log.e("UserRepository", "Error updating disabled status: ${e.message}")
+            Result.failure(e)
+        }
+    }
+
+
 }


### PR DESCRIPTION
This commit introduces the ability for administrators to manage user roles (admin/non-admin) and account status (enabled/disabled).

- Updates the `User` data model to include an `isDisabled` field.
- Modifies the `UserRepository` to include functions for setting admin and disabled statuses.
- Updates the `AuthViewModel` to prevent login for disabled users and display an error message.
- Updates the `AdminScreen` composable to allow toggling of admin and disabled statuses for each user.
- Updates the `AdminViewModel` to handle admin role upgrades/downgrades and user disabling/enabling.
- Includes immediate UI updates in `AdminViewModel` for disable/enable actions to reflect changes without delay.