### PR TITLE
feat: Implement chat screen with message sending and display

### DIFF
--- a/app/src/main/java/com/example/handballconnect/ui/message/ChatScreen.kt
+++ b/app/src/main/java/com/example/handballconnect/ui/message/ChatScreen.kt
@@ -1,0 +1,356 @@
+package com.example.handballconnect.ui.message
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Card
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.handballconnect.data.model.Message
+import com.example.handballconnect.data.storage.ImageStorageManager
+import com.example.handballconnect.ui.feed.formatTimestamp
+import com.example.handballconnect.util.LocalAwareAsyncImage
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatScreen(
+    conversationId: String,
+    navigateBack: () -> Unit,
+    imageStorageManager: ImageStorageManager,
+    chatViewModel: ChatViewModel = hiltViewModel()
+) {
+    val messagesState by chatViewModel.messagesState.collectAsState()
+    val chatState by chatViewModel.chatState.collectAsState()
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    var messageText by remember { mutableStateOf("") }
+    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
+    val listState = rememberLazyListState()
+
+    // Load messages when entering the screen
+    LaunchedEffect(conversationId) {
+        chatViewModel.loadMessages(conversationId)
+    }
+
+    // Scroll to bottom when new messages arrive
+    LaunchedEffect(messagesState) {
+        if (messagesState is MessagesState.Success) {
+            val messages = (messagesState as MessagesState.Success).messages
+            if (messages.isNotEmpty()) {
+                listState.animateScrollToItem(messages.size - 1)
+            }
+        }
+    }
+
+    // Handle chat state changes
+    LaunchedEffect(chatState) {
+        when (chatState) {
+            is ChatState.Success -> {
+                messageText = ""
+                selectedImageUri = null
+            }
+            is ChatState.Error -> {
+                val errorMessage = (chatState as ChatState.Error).message
+                scope.launch {
+                    snackbarHostState.showSnackbar(errorMessage)
+                }
+            }
+            else -> {}
+        }
+    }
+
+    val imagePicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri: Uri? ->
+        selectedImageUri = uri
+        if (uri != null) {
+            chatViewModel.sendImageMessage(uri, conversationId)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clip(CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            // Use profile pic or default icon
+                            Icon(Icons.Filled.Person, contentDescription = "Contact")
+                        }
+
+                        Spacer(modifier = Modifier.width(12.dp))
+
+                        Text(
+                            text = chatViewModel.getOtherParticipantName(),
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                },
+                navigationIcon = {
+                    IconButton(onClick = navigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+        ) {
+            // Messages list
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {
+                when (messagesState) {
+                    is MessagesState.Loading -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
+
+                    is MessagesState.Success -> {
+                        val messages = (messagesState as MessagesState.Success).messages
+                        LazyColumn(
+                            state = listState,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = 16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            contentPadding = PaddingValues(
+                                top = 8.dp,
+                                bottom = 8.dp
+                            )
+                        ) {
+                            items(messages) { message ->
+                                MessageItem(
+                                    message = message,
+                                    currentUserId = chatViewModel.getCurrentUserId() ?: "",
+                                    imageStorageManager = imageStorageManager
+                                )
+                            }
+                        }
+                    }
+
+                    is MessagesState.Empty -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text("No messages yet. Start the conversation!")
+                        }
+                    }
+
+                    is MessagesState.Error -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = (messagesState as MessagesState.Error).message,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        }
+                    }
+
+                    else -> {}
+                }
+            }
+
+            // Message input
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                shape = RoundedCornerShape(24.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = { imagePicker.launch("image/*") }) {
+                        Icon(
+                            Icons.Default.Image,
+                            contentDescription = "Add Image",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+
+                    OutlinedTextField(
+                        value = messageText,
+                        onValueChange = { messageText = it },
+                        modifier = Modifier.weight(1f),
+                        placeholder = { Text("Type a message...") },
+                        singleLine = true,
+                        shape = RoundedCornerShape(24.dp)
+                    )
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    IconButton(
+                        onClick = {
+                            if (messageText.isNotBlank()) {
+                                chatViewModel.sendTextMessage(messageText, conversationId)
+                            }
+                        },
+                        enabled = messageText.isNotBlank() && chatState !is ChatState.Sending
+                    ) {
+                        if (chatState is ChatState.Sending) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp
+                            )
+                        } else {
+                            Icon(
+                                Icons.AutoMirrored.Filled.Send,
+                                contentDescription = "Send",
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun MessageItem(
+    message: Message,
+    currentUserId: String,
+    imageStorageManager: ImageStorageManager
+) {
+    val isCurrentUser = message.senderId == currentUserId
+    val alignment = if (isCurrentUser) Alignment.End else Alignment.Start
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+    ) {
+        // Message bubble
+        Card(
+            shape = RoundedCornerShape(
+                topStart = 12.dp,
+                topEnd = 12.dp,
+                bottomStart = if (isCurrentUser) 12.dp else 4.dp,
+                bottomEnd = if (isCurrentUser) 4.dp else 12.dp
+            ),
+            modifier = Modifier
+                .align(alignment)
+                .padding(horizontal = 8.dp)
+                .padding(bottom = 4.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(12.dp)
+            ) {
+                // Image if present
+                message.imageUrl?.let { imageUrl ->
+                    if (imageUrl.isNotEmpty()) {
+                        LocalAwareAsyncImage(
+                            imageReference = imageUrl,
+                            imageStorageManager = imageStorageManager,
+                            contentDescription = "Message image",
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(180.dp)
+                                .clip(RoundedCornerShape(8.dp)),
+                            contentScale = ContentScale.Crop,
+                            fallbackImageUrl = null
+                        )
+
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
+
+                // Text content
+                if (message.text.isNotEmpty() && message.text != "[Image]") {
+                    Text(
+                        text = message.text,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // Timestamp
+                Text(
+                    text = formatTimestamp(message.timestamp),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
+                    modifier = Modifier.align(Alignment.End)
+                )
+            }
+        }
+    }
+}
+
+//// Helper function for time-only formatting
+//fun formatTimeOnly(timestamp: Long): String {
+//    val formatter = java.text.SimpleDateFormat("HH:mm", java.util.Locale.getDefault())
+//    return formatter.format(java.util.Date(timestamp))
+//}

--- a/app/src/main/java/com/example/handballconnect/ui/message/ChatViewModel.kt
+++ b/app/src/main/java/com/example/handballconnect/ui/message/ChatViewModel.kt
@@ -1,0 +1,154 @@
+package com.example.handballconnect.ui.message
+
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.handballconnect.data.model.Conversation
+import com.example.handballconnect.data.model.User
+import com.example.handballconnect.data.repository.MessageRepository
+import com.example.handballconnect.data.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ChatViewModel @Inject constructor(
+    private val messageRepository: MessageRepository,
+    private val userRepository: UserRepository
+) : ViewModel() {
+
+    // Messages state
+    private val _messagesState = MutableStateFlow<MessagesState>(MessagesState.Initial)
+    val messagesState: StateFlow<MessagesState> = _messagesState.asStateFlow()
+
+    // Message sending state
+    private val _chatState = MutableStateFlow<ChatState>(ChatState.Initial)
+    val chatState: StateFlow<ChatState> = _chatState.asStateFlow()
+
+    // Selected conversation
+    private val _selectedConversation = MutableStateFlow<Conversation?>(null)
+    val selectedConversation: StateFlow<Conversation?> = _selectedConversation.asStateFlow()
+
+    // Send a text message with improved error handling
+    fun sendTextMessage(text: String, conversationId: String) {
+        _chatState.value = ChatState.Sending
+
+        viewModelScope.launch {
+            try {
+                Log.d("ChatViewModel", "Sending message in conversation: $conversationId")
+                val result = messageRepository.sendTextMessage(conversationId, text)
+
+                result.onSuccess {
+                    Log.d("ChatViewModel", "Message sent successfully")
+                    _chatState.value = ChatState.Success
+                }.onFailure { exception ->
+                    Log.e("ChatViewModel", "Failed to send message: ${exception.message}")
+                    _chatState.value =
+                        ChatState.Error(exception.message ?: "Failed to send message")
+                }
+            } catch (e: Exception) {
+                Log.e("ChatViewModel", "Exception sending message: ${e.message}")
+                _chatState.value =
+                    ChatState.Error(e.message ?: "An unexpected error occurred")
+            }
+        }
+    }
+
+    // Send an image message
+    fun sendImageMessage(imageUri: Uri, conversationId: String) {
+        _chatState.value = ChatState.Sending
+
+        viewModelScope.launch {
+            try {
+                val result = messageRepository.sendImageMessage(conversationId, imageUri)
+
+                result.onSuccess {
+                    _chatState.value = ChatState.Success
+                }.onFailure { exception ->
+                    _chatState.value =
+                        ChatState.Error(exception.message ?: "Failed to send image")
+                }
+            } catch (e: Exception) {
+                _chatState.value =
+                    ChatState.Error(e.message ?: "An unexpected error occurred")
+            }
+        }
+    }
+
+    // Set the currently selected conversation
+    fun selectConversation(conversation: Conversation) {
+        _selectedConversation.value = conversation
+        loadMessages(conversation.conversationId)
+    }
+
+    // Get the current user ID
+    fun getCurrentUserId(): String? {
+        return userRepository.getCurrentUserId()
+    }
+
+    // Get other participant's name in current conversation
+    fun getOtherParticipantName(): String {
+        val conversation = _selectedConversation.value ?: return ""
+        val currentUserId = userRepository.getCurrentUserId() ?: return ""
+
+        // Get the name of the other participant
+        return conversation.participantNames[getOtherParticipantId(conversation, currentUserId)] ?: ""
+    }
+
+    // Helper function to get the other participant's ID
+    private fun getOtherParticipantId(conversation: Conversation, currentUserId: String): String {
+        return conversation.participantIds.firstOrNull { it != currentUserId } ?: ""
+    }
+
+    // Load messages for a conversation
+    fun loadMessages(conversationId: String) {
+        _messagesState.value = MessagesState.Loading
+
+        viewModelScope.launch {
+            try {
+                // Load conversation data if not already loaded
+                if (_selectedConversation.value == null || _selectedConversation.value?.conversationId != conversationId) {
+                    val conversationResult = messageRepository.getConversationById(conversationId)
+                    conversationResult.onSuccess { conversation ->
+                        _selectedConversation.value = conversation
+                    }
+                }
+
+                // Load messages
+                messageRepository.getMessagesForConversation(conversationId).collect { result ->
+                    result.onSuccess { messages ->
+                        if (messages.isEmpty()) {
+                            _messagesState.value = MessagesState.Empty
+                        } else {
+                            _messagesState.value = MessagesState.Success(messages)
+                        }
+                    }.onFailure { exception ->
+                        _messagesState.value =
+                            MessagesState.Error(exception.message ?: "Failed to load messages")
+                    }
+                }
+            } catch (e: Exception) {
+                _messagesState.value =
+                    MessagesState.Error(e.message ?: "An unexpected error occurred")
+            }
+        }
+    }
+
+    // Reset chat state
+    fun resetChatState() {
+        _chatState.value = ChatState.Initial
+    }
+}
+
+
+// Users state sealed class
+sealed class UsersState {
+    object Loading : UsersState()
+    object Empty : UsersState()
+    data class Success(val users: List<User>) : UsersState()
+    data class Error(val message: String) : UsersState()
+}


### PR DESCRIPTION
This commit introduces the chat screen functionality, enabling users to send text and image messages within a conversation.

- Creates `ChatViewModel` to manage message sending, loading, and conversation details.
- Implements `ChatScreen` composable for displaying messages, handling user input, and showing loading/error states.
- Adds `MessageItem` composable to render individual messages with text, images, and timestamps.
- Includes functionality for selecting and sending images, with corresponding UI updates.
- Integrates `ImageStorageManager` for image handling.
- Displays the other participant's name in the top app bar.
- Implements scrolling to the bottom of the message list on new message arrival.
- Shows a snackbar for error messages.